### PR TITLE
resolve the issue that a variable in TextNode can't be parsed.

### DIFF
--- a/src/com/rethrick/jade/TextNode.java
+++ b/src/com/rethrick/jade/TextNode.java
@@ -21,6 +21,11 @@ class TextNode extends Node {
     if (line.startsWith("!")) {
       this.line = line.substring(1);
       escape = false;
+    }else{
+        Matcher matcher = TextNode.START_OF_EXPR.matcher(this.line);
+        if (matcher.find()) {
+          this.line = matcher.replaceAll("@{");
+        }
     }
   }
 


### PR DESCRIPTION
``` javascript
html
  body
    p hello, #{message}
```

the `#{message}` can be parsed and replaced with right content, however, 

``` javascript
html
  body
    p
      |hello, #{message}
```

the `#{message}` above can't
